### PR TITLE
Remove empty delivery_addresses

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -157,7 +157,7 @@ class Configuration implements ConfigurationInterface
                     ->performNoDeepMerging()
                     ->beforeNormalization()
                         ->ifArray()
-                        ->then(function ($v) { return array_values($v); })
+                        ->then(function ($v) { return array_filter(array_values($v)); })
                     ->end()
                     ->prototype('scalar')
                     ->end()


### PR DESCRIPTION
Right now it's not possible to easily toggle the forced recipients of emails using the `delivery_addresses` configuration option during development.

Consider the following configuration:

app/config/parameters.yml
```yaml
parameters:
   delivery_address: ~
```

app/config/config_dev.yml
```yaml
swiftmailer:
    delivery_addresses: ["%delivery_address%"]
```

This will currently set the `$_recipient` property within the RedirectingPlugin to `[0 => null]` , which prevents the email from being sent to anyone. Since there's no logging within the RedirectingPlugin, it's difficult to figure out why mailer isn't sending out any emails.